### PR TITLE
Added locale support to properly display Mercurial commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can specify some environment variables:
 * `KALLITHEA_ADMIN_USER` - administrator login (default: `admin`)
 * `KALLITHEA_ADMIN_PASS` - administrator password (default: `admin`)
 * `KALLITHEA_ADMIN_MAIL` - administrator e-mail (default: `admin@example.com`)
+* `KALLITHEA_LOCALE` - set locale to properly display Mercurial commit messages
+   with non-ASCII symbols ("ru_RU.UTF-8" by default)
 
 If you don't have kallithea configuration file (running first time or without mounting a configuration volume), 
 you can set additional variables:

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,11 @@ KALLITHEA_ADMIN_USER=${KALLITHEA_ADMIN_USER:-"admin"}
 KALLITHEA_ADMIN_PASS=${KALLITHEA_ADMIN_PASS:-"admin"}
 KALLITHEA_ADMIN_MAIL=${KALLITHEA_ADMIN_MAIL:-"admin@example.com"}
 
+LANG=${KALLITHEA_LOCALE:-"ru_RU.UTF-8"}
+
+export LANG
+locale-gen --lang ${LANG}
+
 cd /kallithea/config
 
 if [ ! -e kallithea.ini ]; then


### PR DESCRIPTION
Привет!

Я добавил поддержку установки локали перед запуском Kallithea -  без неё комментарии к коммитам (по крайней мере в Mercurial) вместо русских символов отображались знаками вопроса.